### PR TITLE
Added Docker Compose files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# Base image
+FROM node:14-alpine
+
+# Set working directory
+WORKDIR /app
+
+# Copy package.json and yarn.lock to the container
+COPY package.json .
+COPY yarn.lock .
+
+# Install dependencies
+RUN yarn install --production
+
+# Copy the rest of the app
+COPY . .
+
+# Expose port 3000
+EXPOSE 3000
+
+# Start the app
+CMD ["yarn", "start"]

--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ yarn start
 ```
 This will start the project in your terminal. Simply enter your API key and then use it as normal.
 
+## Docker
+
+TurboGPT's server can be instantiated in Docker. The server will automatically restart with Docker. 
+
+```bash
+docker-compose up -d --build
+```
+
 ## Contributing
 
 We welcome and encourage contributions to TurboGPT. To contribute to the project, please follow these steps:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '3.8'
+services:
+  turbogpt:
+    build: .
+    restart: always
+    ports:
+      - "3000:3000"


### PR DESCRIPTION
Creates a Docker container with TurboGPT within. Docker-compose is setup to restart the container automatically. Included updated README.md. I want to include this so that others can quickly do this without repeating the work. I personally run it on Docker for Windows (I use wsl2/ubuntu as well) and the turbogpt service is always available for my browser.